### PR TITLE
Add asearch.liquid component to theme layout

### DIFF
--- a/layout/theme.liquid
+++ b/layout/theme.liquid
@@ -53,4 +53,5 @@
         {{ 'toc.js' | script_tag }}
     {% endif %}
     {% component 'alang.liquid' %}
+    {% component 'asearch.liquid' %}
 </html>


### PR DESCRIPTION
I had missed to add the asearch component to the theme layout, that is why the search didn't show up.